### PR TITLE
Improve focus behavior when takeFocus true

### DIFF
--- a/src/ui/Overlay.java
+++ b/src/ui/Overlay.java
@@ -54,6 +54,7 @@ public class Overlay
         setSize(width, height);//build components with given size
 
         frame.setFocusableWindowState(Main.options.getOptionBool("takeFocus"));//set the focus mode
+        frame.setAutoRequestFocus(false); // prevent auto focus when takeFocus is disabled when using setVisible
         //frame.pack();
         frame.setVisible(true);
         frame.setFocusable(false);

--- a/src/ui/UI.java
+++ b/src/ui/UI.java
@@ -123,10 +123,12 @@ public class UI implements MouseListener, MouseMotionListener, MouseWheelListene
     {
         Graphics2D g = disp.getGraphics();
         g.setBackground(CLEAR);
-        disp.getFrame().setVisible(!hidden);
-        
-        calculateSizes(g);
 
+        disp.getFrame().setFocusableWindowState(false); // prevent setVisible(true) from focusing window when window was previously not visible
+        disp.getFrame().setVisible(!hidden);
+        disp.getFrame().setFocusableWindowState(Main.options.getOptionBool("takeFocus")); // restore setting
+
+        calculateSizes(g);
 
         if(!hidden)
         {


### PR DESCRIPTION
The window is always brought to the top, so when click-focus is enabled, it should never take focus otherwise. This is basically a java problem though.

The change in Overlay makes the window not take focus whenever it rerenders.

The change in UI makes the window not take focus when it goes from not visible to visible.

If spark reader ever gets a setting to disable always being on top, the change in UI would have to take that into account.