### PR TITLE
Fix wordsplitter using epwing on nonfirst sections

### DIFF
--- a/src/language/splitter/WordSplitter.java
+++ b/src/language/splitter/WordSplitter.java
@@ -51,6 +51,7 @@ public class WordSplitter
             x = word.endX();
         }
     }
+    
     // not in dictionary, see if adding possible deconjugation match endings to it gives us a dictionary entry (fixes 振り返ります etc)
     private boolean mightBeDeconjugatable(String text, boolean firstSection)
     {
@@ -63,7 +64,8 @@ public class WordSplitter
                 goodMatch = true;
         }
         return goodMatch;
-}
+    }
+
     private List<FoundWord> splitSection(String text, boolean firstSection)
     {
         ArrayList<FoundWord> words = new ArrayList<>();


### PR DESCRIPTION
I don't have an epwing dictionary so I don't know if the logic is still correct with this change.